### PR TITLE
PyTorch-Lightning Integration for Opacus

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -16,4 +16,5 @@ datasets
 transformers
 scikit-learn
 pytorch-lightning
+lightning-bolts
 jsonargparse[signatures]>=3.19.3 # required for Lightning CLI

--- a/opacus/lightning.py
+++ b/opacus/lightning.py
@@ -71,7 +71,7 @@ class DPLightningDataModule(pl.LightningDataModule):
         return self.datamodule.on_after_batch_transfer(batch, dataloader_idx)
 
 
-class OpacusCallback(pl.Callback):
+class LightningPrivacyEngine(pl.Callback):
 
     def __init__(
         self,


### PR DESCRIPTION
Follow-up for [this pull request](https://github.com/pytorch/opacus/pull/244). An attempt to make an seamless integration of Opacus with PyTorch-Lightning. We implement this using callbacks feature.

No changes in `LightningModule`.

```python
def main():
    # Look ma, no privacy burden here!
    data = MNISTDataModule()
    model = LitSampleConvNetClassifier()

    # Here we add some privacy
    privacy_engine = LightningPrivacyEngine(
        delta=1e-5,
        sample_rate=0.001,
        # etc
    )
    privacy_data = privacy_engine.wrap_datamodule(data)

    # Now we go
    trainer = pl.Trainer(
        max_epochs=2,
        enable_model_summary=False,
        callbacks=[privacy_engine],
    )
    trainer.fit(model, privacy_data)

    # TODO:
    # trainer.fit(model, data)
    # Must crash with the message: either remove PrivacyEngine or use certified data modules

    trainer.test(model, data)
    trainer.test(model, privacy_data)  # identical
```